### PR TITLE
Add account proof as a domain tag

### DIFF
--- a/src/main/kotlin/com/nftco/flow/sdk/domain-tags.kt
+++ b/src/main/kotlin/com/nftco/flow/sdk/domain-tags.kt
@@ -9,6 +9,9 @@ object DomainTag {
     val USER_DOMAIN_TAG = normalize("FLOW-V0.0-user")
 
     @JvmStatic
+    val ACCOUNT_PROOF_DOMAIN_TAG = normalize("FCL-ACCOUNT-PROOF-V0.0")
+
+    @JvmStatic
     fun normalize(tag: String): ByteArray {
         val bytes = tag.toByteArray(Charsets.UTF_8)
         return when {


### PR DESCRIPTION
## Description

Add account proof domain tag for FCL

[Reference](https://github.com/onflow/fcl-js/blob/master/packages/fcl/src/wallet-utils/encode-account-proof.js#L38)
